### PR TITLE
Added new features, temperature readout, current fan speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,18 +3,37 @@
 Author: DominiLux
 License: Apache Version 2.0
 
-This is an alpha release written in unix style bash script.  It is a simple utility that allows you to set the fan speeds for AMD cards that support use the AMD GPU PRO driver.  There are many features I will be adding to this over the coming days and weeks as I use bash script to experiment with direct manipulation of the hardware.
+This is an alpha release written in unix style bash script.  It is a simple utility that allows you to set the fan speeds for AMD cards that support use the AMD GPU PRO driver.  There are many features I will be adding to this over the coming days and weeks.
 
-This is the first phase in a multi phase project to attempt to create an aticonfig/fglrx emulator so that existing applications using old SDK's will still have an interface to connect to the cards for hardware monitoring.  I look forward to developing this for the open sourced community.  The version uploaded right now only sets the fan speeds.  Everything else I already know how to to do.  However, I have to find the time to code it first.
+## Stable Branch
+The current master branch is considered the stable release.  The code in the development branch may not have been fully tested.
 
 ## Installation Instructions:
 * sudo apt-get install git
-* git clone https://github.com/dominilux/amdgpu-pro-fans
+* git clone https://github.com/darkjarris/amdgpu-pro-fans
 * cd amdgpu-pro-fans
 * chmod +x amdgpu-pro-fans.sh
 
 ## Usage:
-sudo ./amdgpu-pro-fans.sh --speed=(0 - 100)
+sudo ./amdgpu-pro-fans.sh -s [speed 0 - 100]
+./amdgpu-pro-fans.sh -t
+./amdgpu-pro-fans.sh -r
+./amdgpu-pro-fans.sh -h
+
+## Usage Example:
+sudo ./amdgpu-pro-fans.sh -s 80
+This would set all of your fan speeds to 80 percent of their maximum speed.  The argument works perfectly as of the current stable release.
+
+./amdgpu-pro-fans.sh -t
+This will show the current temperature in Centigrade.
+
+./amdgpu-pro-fans.sh -r
+This will show current fan speed percentage.
+
+./amdgpu-pro-fans.sh -h
+This shows the help feature (was missing)
 
 ## Notes:
-This version defaults to all adapters.  The next flag I will be adding will be the --adapter flag to allow a user to specify any specific number of adapters or all adapters.  I also plan on adding a get temperature feature to it as well.  This is Revision 0.1.0 so it's likely to throw some random errors and things as I have not debugged it much.  I will be moving through the revisions of this project very quickly to have the concepts laid out for the c++ application I mentioned earlier.
+Fully tested on Ubuntu 16.04 with AMDGPU-PRO proprietary linux drivers.  It is now compatible with all Radeon R8 Series, R9 Series, and RX Series graphics cards.  I will be adding the option to specify a specific adapter soon.  It will be in the works in the development branch and I will merge it here once it's coded, tested, and debugged.
+
+This version defaults to all adapters.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# Depricated For Replacement C++ Project
+I have depricated this project as it was meant to be an example.  I am currently developing my new project in C++ and will have a release ready soon.  It's name is GPUMAGIC and it is specifically engineered not just for mining but for managing any large compute cluster which uses **AMD** Graphics Cards.  You can get more information on it in my repository GPUMAGIC which is also the future home of the code (currently in testing and debugging)
+
+
 # amdgpu-pro-fans
 
 Author: DominiLux
@@ -19,6 +23,7 @@ sudo ./amdgpu-pro-fans.sh -s [speed 0 - 100]
 ./amdgpu-pro-fans.sh -t
 ./amdgpu-pro-fans.sh -r
 ./amdgpu-pro-fans.sh -h
+./amdgpu-pro-fans.sh -v [0,1] (default 1)
 
 ## Usage Example:
 sudo ./amdgpu-pro-fans.sh -s 80
@@ -32,6 +37,24 @@ This will show current fan speed percentage.
 
 ./amdgpu-pro-fans.sh -h
 This shows the help feature (was missing)
+
+./amdgpu-pro-fans.sh -v
+This sets verbosity. 0 is simple output, 1 is verbose output. default is 1. 
+
+
+If you wish to change verbosity to 0, use the flag before asking for output, examples given: 
+./amdgpu-pro-fans.sh -v 1 -r
+Fan speed on Card0 is 100%
+
+./amdgpu-pro-fans.sh -v 0 -r
+100
+
+./amdgpu-pro-fans.sh -t -v 0
+$0: invalid option -- ' '
+$0: invalid option -- '-'
+Temperature on Card0 is 51%
+
+
 
 ## Notes:
 Fully tested on Ubuntu 16.04 with AMDGPU-PRO proprietary linux drivers.  It is now compatible with all Radeon R8 Series, R9 Series, and RX Series graphics cards.  I will be adding the option to specify a specific adapter soon.  It will be in the works in the development branch and I will merge it here once it's coded, tested, and debugged.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The current master branch is considered the stable release.  The code in the dev
 
 ## Installation Instructions:
 * sudo apt-get install git
-* git clone https://github.com/darkjarris/amdgpu-pro-fans
+* git clone https://github.com/dominilux/amdgpu-pro-fans
 * cd amdgpu-pro-fans
 * chmod +x amdgpu-pro-fans.sh
 

--- a/REVISIONS
+++ b/REVISIONS
@@ -1,3 +1,8 @@
+Version 0.2.1
+	- Added Verbosity flag  [-v] 0= no verbosity. 1= verbose output. default 1.
+	- Typo fixes for $cardcount
+	- fixed README
+
 Version 0.2.0
 
 	- Added current temperature readout [-t]

--- a/REVISIONS
+++ b/REVISIONS
@@ -1,0 +1,36 @@
+Version 0.2.0
+
+	- Added current temperature readout [-t]
+	- Added current fan speed readout [-r]
+	- Expanded and enabled help switch [-h]
+	- Updated README
+
+Version 0.1.5
+
+	- Now works with all AMD Radeon R8, R9, and RX Series Cards
+	- [-s] switch has been fully implmented and debugged to specificy your speed
+	- cross linux distribution compatibility resolved
+	- Code tested and considered stable now
+
+Version 0.1.4
+	- Added patch to work with R9 and RX Cards
+	- Should be fully supported with latest AMDGPU-PRO driver on ubuntu 16.04.
+
+Version 0.1.3
+
+	- Added command line parsing function
+	- Added usage function
+	- Detects the [-s] switch for specifying fan speed in percentages
+	- Get's the [-a] adapter variable from the command line which will be used in other alpha revisions
+
+Version 0.1.2
+
+	- Major improvements to dynamic card detection algorythm
+
+Version 0.1.1
+
+	- Implimented Functions For Portability
+
+Version 0.1.0
+
+	- Initial alpha code upload

--- a/amdgpu-pro-fans.sh
+++ b/amdgpu-pro-fans.sh
@@ -3,7 +3,7 @@
 #  AMDGPU-PRO LINUX UTILITIES SUITE  #
 ######################################
 # Utility Name: AMDGPU-PRO-FANS
-# Version: 0.2.0
+# Version: 0.2.1
 # Version Name: MahiMahi
 # https://github.com/DominiLux/amdgpu-pro-fans
 


### PR DESCRIPTION
I've added a few features and fix a bug where the -h flag didnt work
- Added current temperature readout [-t]
- Added current fan speed readout [-r]
- Expanded and enabled help switch [-h]

I'm going to be making a python GUI for this and needed a way to retrieve what the actual fan speed was, and the temperature is a nice bonus too.

As the new outputs are intended to be passed into another program, I kept the outputs super simple. just a basic integer "100", "85", "52", etc; rather than the prettier "Card temperature is 52C" or so.

I shall probably add a verbosity flag to switch between the two, so its readable by human or computer. but that will come later some time.